### PR TITLE
Add Cross-compile for RISC-V in Makefile

### DIFF
--- a/picolm/Makefile
+++ b/picolm/Makefile
@@ -28,7 +28,7 @@ pi-arm32: CC = arm-linux-gnueabihf-gcc
 pi-arm32: CFLAGS += -march=armv6 -mfpu=vfp
 pi-arm32: $(TARGET)
 
-# --- Cross-compile for Pi from x86 ---
+# --- Cross-compile for Pi64 from platforms (e.g. x86) ---
 cross-pi: CC = aarch64-linux-gnu-gcc
 cross-pi: CFLAGS += -march=armv8-a+simd
 cross-pi: LDFLAGS += -static
@@ -38,6 +38,12 @@ cross-pi: $(TARGET)
 riscv: CC = riscv64-linux-gnu-gcc
 riscv: CFLAGS += -march=rv64gc -mabi=lp64d
 riscv: $(TARGET)
+
+# --- Cross-compile for RISC-V from platforms (e.g. x86) ---
+cross-riscv: CC = riscv64-linux-gnu-gcc
+cross-riscv: CFLAGS += -march=rv64gc -mabi=lp64d
+cross-riscv: LDFLAGS += -static
+cross-riscv: $(TARGET)
 
 # --- Debug build ---
 debug: CFLAGS = -std=c11 -Wall -Wextra -Wpedantic -g -O0
@@ -64,4 +70,4 @@ model:
 clean:
 	rm -f $(TARGET) $(TARGET).exe *.obj *.o
 
-.PHONY: native static pi pi-arm32 cross-pi riscv debug install model clean
+.PHONY: native static pi pi-arm32 cross-pi riscv cross-riscv debug install model clean


### PR DESCRIPTION
## What does this PR do?

add setting for RISC-V Cross-compile

because pi 64 platform already have cross-compile setting
and RISC-V's performance is lowe, might more needed

also LicheeRV Nano only have Buildroot image from official
is easiler to just using cross-compile to set picolm

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no behavior change)

## Testing

- [ ] Tested on x86-64 (Linux/macOS/Windows)
- [ ] Tested on ARM64 (Raspberry Pi)
- [X] Tested on ARM32 (Pi zero)
- [ ] Tested with TinyLlama 1.1B Q4_K_M
- [X] Tested on RISC-V (LicheeRV Nano)

**Test command on Pi zero:**
```bash
make native
make cross-riscv
```

**Output:**
```
(both output completed without error messages)
```

## Checklist

- [X] Code compiles without warnings (`make native`)
- [X] No new dependencies added
- [ ] Memory usage not increased (check stderr output)
- [ ] Works with `--json` mode (if touching generation/sampling)

## Other

I just edit Makefile to add setting, so no extra testing was conducted.

but both RISC-V and ARM32 are work with 
`echo "1+1=?" | ./picolm /opt/picolm/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf -n 100 -j 1`
but generating is too slow and make me want to cry 🤣