### PR TITLE
MinorFix: Corrected the github repo URL for Build from source section

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ This will:
 ### Build from source
 
 ```bash
-git clone https://github.com/picolm/picolm.git
+git clone https://github.com/RightNow-AI/picolm
 cd picolm/picolm
 
 # Auto-detect CPU (enables SSE2/AVX on x86, NEON on ARM)


### PR DESCRIPTION
MinorFix: Corrected the github repo URL(https://github.com/picolm/picolm.git -> https://github.com/RightNow-AI/picolm) for Build from source section