### PR TITLE
Corrected git repo clone command in the build from source section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ This will:
 ### Build from source
 
 ```bash
-git clone https://github.com/RightNow-AI/picolm
+git clone https://github.com/RightNow-AI/picolm.git
 cd picolm/picolm
 
 # Auto-detect CPU (enables SSE2/AVX on x86, NEON on ARM)

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ This will:
 ### Build from source
 
 ```bash
-git clone https://github.com/picolm/picolm.git
+git clone https://github.com/RightNow-AI/picolm
 cd picolm/picolm
 
 # Auto-detect CPU (enables SSE2/AVX on x86, NEON on ARM)


### PR DESCRIPTION
Corrected git repo clone command in the build from source section from:
git clone https://github.com/picolm/picolm ->git clone https://github.com/RightNow-AI/picolm